### PR TITLE
ci: remove reviewdog stage

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,6 +1,6 @@
 stages:
   - reports
-  
+
 bearer:
   stage: reports
   only:
@@ -13,13 +13,3 @@ bearer:
   artifacts:
     reports:
       sast: gl-sast-report.json
-
-bearer_mr_check:
-  stage: reports
-  only:
-    - merge_requests
-  script:
-    - curl -sfL https://raw.githubusercontent.com/Bearer/bearer/main/contrib/install.sh | sh -s -- -b /usr/local/bin
-    - curl -sfL https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh | sh -s -- -b /usr/local/bin
-    - bearer scan . --format=rdjson --output=rd.json
-    - cat rd.json | reviewdog -f=rdjson -reporter=gitlab-mr-discussion


### PR DESCRIPTION
Following recent [supply chain attack on some GitHub Actions](https://www.wiz.io/blog/new-github-action-supply-chain-attack-reviewdog-action-setup), we remove reviewdog from our dormant repositories.